### PR TITLE
Revert "Add FinRem - DraftStore micro service to s2s auth (#51)"

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -98,14 +98,6 @@ data "vault_generic_secret" "emGw" {
   path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/em-gw"
 }
 
-data "vault_generic_secret" "finRem" {
-  path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/finrem"
-}
-
-data "vault_generic_secret" "finRemDraftStore" {
-  path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/finrem-draft-store"
-}
-
 # region: for functional/smoke tests
 # todo: create a separate test service just for this app
 data "vault_generic_secret" "test_s2s_secret" {
@@ -157,8 +149,6 @@ module "s2s-api" {
     AUTH_PROVIDER_SERVICE_SERVER_MICROSERVICE_KEYS_REFERENCE                  = "${data.vault_generic_secret.reference.data["value"]}"
     AUTH_PROVIDER_SERVICE_SERVER_MICROSERVICE_KEYS_EM_GW                      = "${data.vault_generic_secret.emGw.data["value"]}"
     AUTH_PROVIDER_SERVICE_SERVER_MICROSERVICE_KEYS_CMC_CLAIM_STORE            = "${data.vault_generic_secret.cmcClaimStore.data["value"]}"
-    AUTH_PROVIDER_SERVICE_SERVER_MICROSERVICE_KEYS_FINREM                     = "${data.vault_generic_secret.finRem.data["value"]}"
-    AUTH_PROVIDER_SERVICE_SERVER_MICROSERVICE_KEYS_FINREM_DRAFT_STORE         = "${data.vault_generic_secret.finRemDraftStore.data["value"]}"
     AUTH_PROVIDER_SERVICE_SERVER_MICROSERVICE_KEYS_CCD_PS                     = "${data.vault_generic_secret.ccdPs.data["value"]}"
     AUTH_PROVIDER_SERVICE_TESTING_SUPPORT_ENABLED                             = "${var.testing_support}"
   }


### PR DESCRIPTION
Missing entry in the key vault blocks certain environments.

To be restored later.

This reverts commit 1abc9773cdd2a3e82eb1610bcb08c21c67e910f9.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
