### PR TITLE
Added micro service keys for Financial Remedy frontend (finRem) and finRemDraftStore

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -98,6 +98,14 @@ data "vault_generic_secret" "emGw" {
   path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/em-gw"
 }
 
+data "vault_generic_secret" "finRem" {
+  path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/finrem"
+}
+
+data "vault_generic_secret" "finRemDraftStore" {
+  path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/finrem-draft-store"
+}
+
 # region: for functional/smoke tests
 # todo: create a separate test service just for this app
 data "vault_generic_secret" "test_s2s_secret" {
@@ -150,6 +158,8 @@ module "s2s-api" {
     AUTH_PROVIDER_SERVICE_SERVER_MICROSERVICE_KEYS_EM_GW                      = "${data.vault_generic_secret.emGw.data["value"]}"
     AUTH_PROVIDER_SERVICE_SERVER_MICROSERVICE_KEYS_CMC_CLAIM_STORE            = "${data.vault_generic_secret.cmcClaimStore.data["value"]}"
     AUTH_PROVIDER_SERVICE_SERVER_MICROSERVICE_KEYS_CCD_PS                     = "${data.vault_generic_secret.ccdPs.data["value"]}"
+    AUTH_PROVIDER_SERVICE_SERVER_MICROSERVICE_KEYS_FINREM                     = "${data.vault_generic_secret.finRem.data["value"]}"
+    AUTH_PROVIDER_SERVICE_SERVER_MICROSERVICE_KEYS_FINREM_DRAFT_STORE         = "${data.vault_generic_secret.finRemDraftStore.data["value"]}"
     AUTH_PROVIDER_SERVICE_TESTING_SUPPORT_ENABLED                             = "${var.testing_support}"
   }
 }


### PR DESCRIPTION
Added micro service keys for Financial Remedy frontend (finRem) and finRemDraftStore
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/FR-167

### Change description ###
Added micro service keys for Financial Remedy frontend (finRem) and finRemDraftStore


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
