### PR TITLE
Add bulk scan key to s2s

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -122,8 +122,8 @@ data "vault_generic_secret" "cohcor" {
   path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/coh-cor"
 }
 
-data "vault_generic_secret" "bulkScanUpload" {
-  path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/bulk-scan-upload"
+data "vault_generic_secret" "bulkScanProcessor" {
+  path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/bulk-scan-processor"
 }
 
 # region: for functional/smoke tests
@@ -185,7 +185,7 @@ module "s2s-api" {
     MICROSERVICE_KEYS_JUI_WEBAPP                 = "${data.vault_generic_secret.juiWebapp.data["value"]}"
     MICROSERVICE_KEYS_PUI_WEBAPP                 = "${data.vault_generic_secret.puiWebapp.data["value"]}"
     MICROSERVICE_KEYS_COH_COR                    = "${data.vault_generic_secret.cohcor.data["value"]}"
-    MICROSERVICE_KEYS_BULK_SCAN_UPLOAD           = "${data.vault_generic_secret.bulkScanUpload.data["value"]}"
+    MICROSERVICE_KEYS_BULK_SCAN_PROCESSOR        = "${data.vault_generic_secret.bulkScanProcessor.data["value"]}"
     TESTING_SUPPORT_ENABLED                      = "${var.testing_support}"
   }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -122,6 +122,10 @@ data "vault_generic_secret" "cohcor" {
   path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/coh-cor"
 }
 
+data "vault_generic_secret" "bulkScanUpload" {
+  path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/bulk-scan-upload"
+}
+
 # region: for functional/smoke tests
 # todo: create a separate test service just for this app
 data "vault_generic_secret" "test_s2s_secret" {
@@ -181,6 +185,7 @@ module "s2s-api" {
     MICROSERVICE_KEYS_JUI_WEBAPP                 = "${data.vault_generic_secret.juiWebapp.data["value"]}"
     MICROSERVICE_KEYS_PUI_WEBAPP                 = "${data.vault_generic_secret.puiWebapp.data["value"]}"
     MICROSERVICE_KEYS_COH_COR                    = "${data.vault_generic_secret.cohcor.data["value"]}"
+    MICROSERVICE_KEYS_BULK_SCAN_UPLOAD           = "${data.vault_generic_secret.bulkScanUpload.data["value"]}"
     TESTING_SUPPORT_ENABLED                      = "${var.testing_support}"
   }
 }


### PR DESCRIPTION

### JIRA link (if applicable) ###



### Change description ###

- Bulk scanning component needs to call Document management service which need s2s token.
- Keys added to Hashicorp Vault for test, preprod and prod paths.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
