### PR TITLE
Fix README typo for service config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ ./gradlew build
 ### Configuration
 Services to authenticate are retrieved from environment variables in the following format:
 ```
-MICROSERVICEKEYS_{service}={secret}
+MICROSERVICE_KEYS_{service}={secret}
 ```
 where `{service}` is the name of the service and `{secret}` is a base32 encoded secret used for generating and validating OTP.
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Fix doc for microservices configuration: `MICROSERVICE_KEYS_` instead of `MICROSERVICEKEYS_`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
