### PR TITLE
Accept old sign-in payload

### DIFF
--- a/src/main/java/uk/gov/hmcts/auth/provider/service/api/model/SignIn.java
+++ b/src/main/java/uk/gov/hmcts/auth/provider/service/api/model/SignIn.java
@@ -12,17 +12,15 @@ public class SignIn implements Serializable {
 
     @ApiModelProperty("Name of the microservice")
     @NotEmpty
-    @JsonProperty("microservice")
     public final String microservice;
 
     @ApiModelProperty("Google Authenticator OTP")
     @NotEmpty
-    @JsonProperty("one_time_password")
     public final String oneTimePassword;
 
     public SignIn(
         @JsonProperty("microservice") String microservice,
-        @JsonProperty("one_time_password") String oneTimePassword
+        @JsonProperty("oneTimePassword") String oneTimePassword
     ) {
         this.microservice = microservice;
         this.oneTimePassword = oneTimePassword;


### PR DESCRIPTION
both java client:
https://github.com/hmcts/service-auth-provider-java-client/blob/master/src/main/java/uk/gov/hmcts/reform/authorisation/generators/ServiceAuthTokenGenerator.java#L36

and nodejs client:
https://github.com/hmcts/ccd-api-gateway/blob/master/app/service/service-token-generator.js#L23

send `oneTimePassword` in JSON