### PR TITLE
[PREVIEW] Add config for bulk-scan-orchestrator service

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -233,7 +233,7 @@ locals {
     MICROSERVICEKEYS_COH_COR                    = "${data.vault_generic_secret.cohcor.data["value"]}"
     MICROSERVICEKEYS_BULK_SCAN_PROCESSOR        = "${data.vault_generic_secret.bulkScanProcessor.data["value"]}"
     MICROSERVICEKEYS_BULK_SCAN_PROCESSOR_TESTS  = "${data.vault_generic_secret.bulkScanProcessorTests.data["value"]}"
-    MICROSERVICEKEYS_BULK_SCAN_ORCHESTRATOR     = "${local.microservice_key_settings["BULK_SCAN_ORCHESTRATOR"]}"
+    MICROSERVICEKEYS_BULK_SCAN_ORCHESTRATOR     = "${local.microservice_key_names["BULK_SCAN_ORCHESTRATOR"]}"
     MICROSERVICEKEYS_BAR_API                    = "${data.vault_generic_secret.barApi.data["value"]}"
   }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -233,7 +233,7 @@ locals {
     MICROSERVICEKEYS_COH_COR                    = "${data.vault_generic_secret.cohcor.data["value"]}"
     MICROSERVICEKEYS_BULK_SCAN_PROCESSOR        = "${data.vault_generic_secret.bulkScanProcessor.data["value"]}"
     MICROSERVICEKEYS_BULK_SCAN_PROCESSOR_TESTS  = "${data.vault_generic_secret.bulkScanProcessorTests.data["value"]}"
-    MICROSERVICEKEYS_BULK_SCAN_ORCHESTRATOR     = "${local.microservice_key_names["BULK_SCAN_ORCHESTRATOR"]}"
+    MICROSERVICEKEYS_BULK_SCAN_ORCHESTRATOR     = "${local.microservice_key_settings["MICROSERVICEKEY_BULK_SCAN_ORCHESTRATOR"]}"
     MICROSERVICEKEYS_BAR_API                    = "${data.vault_generic_secret.barApi.data["value"]}"
   }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -130,6 +130,11 @@ data "vault_generic_secret" "bulkScanProcessorTests" {
   path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/bulk-scan-processor-tests"
 }
 
+data "azurerm_key_vault_secret" "bulk-scan-orchestrator" {
+  name      = "microservicekey-bulk-scan-orchestrator"
+  vault_uri = "${module.key-vault.key_vault_uri}"
+}
+
 data "vault_generic_secret" "barApi" {
   path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/bar-api"
 }
@@ -196,6 +201,7 @@ module "s2s-api" {
     MICROSERVICEKEYS_COH_COR                    = "${data.vault_generic_secret.cohcor.data["value"]}"
     MICROSERVICEKEYS_BULK_SCAN_PROCESSOR        = "${data.vault_generic_secret.bulkScanProcessor.data["value"]}"
     MICROSERVICEKEYS_BULK_SCAN_PROCESSOR_TESTS  = "${data.vault_generic_secret.bulkScanProcessorTests.data["value"]}"
+    MICROSERVICEKEYS_BULK_SCAN_ORCHESTRATOR     = "${data.azurerm_key_vault_secret.bulk-scan-orchestrator.value}"
     MICROSERVICEKEYS_BAR_API                    = "${data.vault_generic_secret.barApi.data["value"]}"
     TESTING_SUPPORT_ENABLED                      = "${var.testing_support}"
   }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -143,11 +143,6 @@ data "vault_generic_secret" "bulkScanProcessorTests" {
   path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/bulk-scan-processor-tests"
 }
 
-data "azurerm_key_vault_secret" "bulk-scan-orchestrator" {
-  name      = "microservicekey-bulk-scan-orchestrator"
-  vault_uri = "${module.key-vault.key_vault_uri}"
-}
-
 data "vault_generic_secret" "barApi" {
   path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/bar-api"
 }
@@ -192,6 +187,7 @@ locals {
     "COH_COR"                     = "microservicekey-coh-cor"
     "BULK_SCAN_PROCESSOR"         = "microservicekey-bulk-scan-processor"
     "BULK_SCAN_PROCESSOR_TESTS"   = "microservicekey-bulk-scan-processor-tests"
+    "BULK_SCAN_ORCHESTRATOR"      = "microservicekey-bulk-scan-orchestrator"
     "BAR_API"                     = "microservicekey-bar-api"
   }
 
@@ -237,7 +233,6 @@ locals {
     MICROSERVICEKEYS_COH_COR                    = "${data.vault_generic_secret.cohcor.data["value"]}"
     MICROSERVICEKEYS_BULK_SCAN_PROCESSOR        = "${data.vault_generic_secret.bulkScanProcessor.data["value"]}"
     MICROSERVICEKEYS_BULK_SCAN_PROCESSOR_TESTS  = "${data.vault_generic_secret.bulkScanProcessorTests.data["value"]}"
-    MICROSERVICEKEYS_BULK_SCAN_ORCHESTRATOR     = "${data.azurerm_key_vault_secret.bulk-scan-orchestrator.value}"
     MICROSERVICEKEYS_BAR_API                    = "${data.vault_generic_secret.barApi.data["value"]}"
   }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -233,6 +233,7 @@ locals {
     MICROSERVICEKEYS_COH_COR                    = "${data.vault_generic_secret.cohcor.data["value"]}"
     MICROSERVICEKEYS_BULK_SCAN_PROCESSOR        = "${data.vault_generic_secret.bulkScanProcessor.data["value"]}"
     MICROSERVICEKEYS_BULK_SCAN_PROCESSOR_TESTS  = "${data.vault_generic_secret.bulkScanProcessorTests.data["value"]}"
+    MICROSERVICEKEYS_BULK_SCAN_ORCHESTRATOR     = "${local.microservice_key_settings["BULK_SCAN_ORCHESTRATOR"]}"
     MICROSERVICEKEYS_BAR_API                    = "${data.vault_generic_secret.barApi.data["value"]}"
   }
 }


### PR DESCRIPTION
Note that this new secret is read from the azure vault, not tactical hashicorp vault.
Added secrets in saat, aat and prod.