### PR TITLE
[PREVIEW] Retrieve microservice secrets from Azure Key Vault

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,8 +1,7 @@
 #!groovy
 
 List<LinkedHashMap<String, Object>> secrets = [
-  secret('test-service-name', 'TEST_SERVICE_NAME'),
-  secret('test-service-secret', 'TEST_SERVICE_SECRET')
+  secret('microservicekey-send-letter-tests', 'TEST_SERVICE_SECRET')
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -2,8 +2,7 @@
 @Library("Infrastructure") _
 
 List<LinkedHashMap<String, Object>> secrets = [
-    secret('test-service-name', 'TEST_SERVICE_NAME'),
-    secret('test-service-secret', 'TEST_SERVICE_SECRET')
+    secret('microservicekey-send-letter-tests', 'TEST_SERVICE_SECRET')
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -236,25 +236,6 @@ locals {
   }
 }
 
-# region: for functional/smoke tests
-# todo: create a separate test service just for this app
-data "vault_generic_secret" "test_s2s_secret" {
-  path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/send-letter-tests"
-}
-
-resource "azurerm_key_vault_secret" "test-s2s-name" {
-  name      = "test-service-name"
-  value     = "send_letter_tests"
-  vault_uri = "${module.key-vault.key_vault_uri}"
-}
-
-resource "azurerm_key_vault_secret" "test-s2s-secret" {
-  name      = "test-service-secret"
-  value     = "${data.vault_generic_secret.test_s2s_secret.data["value"]}"
-  vault_uri = "${local.vault_uri}"
-}
-# endregion
-
 module "s2s-api" {
   source       = "git@github.com:hmcts/moj-module-webapp.git?ref=master"
   product      = "${var.product}-${var.component}"

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -9,3 +9,7 @@ output "vaultName" {
 output "microserviceName" {
   value = "${var.component}"
 }
+
+output "test_service_name" {
+  value = "send_letter_tests"
+}

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -1,0 +1,1 @@
+vault_section = "preprod"


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-614

### Change description ###

Retrieve microservice secrets from Azure Key Vault and put them in application settings.

To come after this pull request:
- getting rid of Hashicorp Vault and the application settings that come from its secrets
- making the application use the new settings

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
