### PR TITLE
[PREVIEW] Prevent attempts to create aat vault in preview builds

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -157,12 +157,14 @@ resource "azurerm_key_vault_secret" "test-s2s-name" {
   name      = "test-service-name"
   value     = "send_letter_tests"
   vault_uri = "${local.vault_uri}"
+  count     = "${local.is_preview ? 0 : 1}"
 }
 
 resource "azurerm_key_vault_secret" "test-s2s-secret" {
   name      = "test-service-secret"
   value     = "${data.vault_generic_secret.test_s2s_secret.data["value"]}"
   vault_uri = "${local.vault_uri}"
+  count     = "${local.is_preview ? 0 : 1}"
 }
 # endregion
 
@@ -215,7 +217,7 @@ module "s2s-api" {
 }
 
 module "key-vault" {
-  source              = "git@github.com:hmcts/moj-module-key-vault?ref=master"
+  source              = "git@github.com:hmcts/moj-module-key-vault?ref=feature/add-count-input-variable"
   product             = "s2s"
   env                 = "${var.env}"
   tenant_id           = "${var.tenant_id}"
@@ -223,4 +225,5 @@ module "key-vault" {
   resource_group_name = "${module.s2s-api.resource_group_name}"
   # dcd_reform_dev_logs group object ID
   product_group_object_id = "70de400b-4f47-4f25-a4f0-45e1ee4e4ae3"
+  count               = "${local.is_preview ? 0 : 1}"
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -157,14 +157,12 @@ resource "azurerm_key_vault_secret" "test-s2s-name" {
   name      = "test-service-name"
   value     = "send_letter_tests"
   vault_uri = "${local.vault_uri}"
-  count     = "${local.is_preview ? 0 : 1}"
 }
 
 resource "azurerm_key_vault_secret" "test-s2s-secret" {
   name      = "test-service-secret"
   value     = "${data.vault_generic_secret.test_s2s_secret.data["value"]}"
   vault_uri = "${local.vault_uri}"
-  count     = "${local.is_preview ? 0 : 1}"
 }
 # endregion
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -3,7 +3,16 @@ provider "vault" {
 }
 
 locals {
-  vault_env = "${var.env == "preview" ? "aat" : var.env}"
+  is_preview          = "${var.env == "preview" || var.env == "spreview"}"
+
+  # environment whose vault should be used by preview
+  vault_env           = "${var.env == "preview" ? "aat" : var.env == "spreview" ? "saat" : var.env }"
+
+  preview_vault_uri   = "https://s2s-${local.vault_env}.vault.azure.net/"
+  vault_uri           = "${local.is_preview ? local.preview_vault_uri : module.key-vault.key_vault_uri}"
+
+  preview_vault_name  = "s2s-${local.vault_env}"
+  vault_name          = "${local.is_preview ? local.preview_vault_name : module.key-vault.key_vault_name}"
 }
 
 data "vault_generic_secret" "jwtKey" {
@@ -147,13 +156,13 @@ data "vault_generic_secret" "test_s2s_secret" {
 resource "azurerm_key_vault_secret" "test-s2s-name" {
   name      = "test-service-name"
   value     = "send_letter_tests"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${local.vault_uri}"
 }
 
 resource "azurerm_key_vault_secret" "test-s2s-secret" {
   name      = "test-service-secret"
   value     = "${data.vault_generic_secret.test_s2s_secret.data["value"]}"
-  vault_uri = "${module.key-vault.key_vault_uri}"
+  vault_uri = "${local.vault_uri}"
 }
 # endregion
 
@@ -208,7 +217,7 @@ module "s2s-api" {
 module "key-vault" {
   source              = "git@github.com:hmcts/moj-module-key-vault?ref=master"
   product             = "s2s"
-  env                 = "${local.vault_env}"
+  env                 = "${var.env}"
   tenant_id           = "${var.tenant_id}"
   object_id           = "${var.jenkins_AAD_objectId}"
   resource_group_name = "${module.s2s-api.resource_group_name}"

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,9 +1,9 @@
 output "vaultUri" {
-  value = "${module.key-vault.key_vault_uri}"
+  value = "${local.vault_uri}"
 }
 
 output "vaultName" {
-  value = "${module.key-vault.key_vault_name}"
+  value = "${local.vault_name}"
 }
 
 output "microserviceName" {


### PR DESCRIPTION
### Change description ###

Preview S2S uses AAT vault, but its terraform code also tries to create it. This pull request prevents that from happening. It still creates a preview (not aat) vault, as you can't set count to 0, but doesn't use it.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
