### PR TITLE
[PREVIEW] Use secrets from Azure Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In order to setup Service Auth Provider to work with a client service, you need 
 * In the Azure Key Vault named `s2s-{environment}` add the service's secret used for generating OTPs (one-time passwords).
 This has to be done in each environment the service is going to be deployed to. Service Auth Provider will use that secret
 for validating OTPs. It has to be a BASE32-encoded sequence of ten random bytes (16 characters after encoding). By convention,
-the Azure Key Vault secret's name should follow this format: `microservicekey-{service-name}`.
+the Azure Key Vault secret's name should follow this format: `microservicekey-{service-name}`. [Here's](#generating-secret) how to generate it.
 * Add the client service to `local.microservice_key_names` map in [main.tf](infrastructure/main.tf). The key has to be
 the service name (as in HTTP requests) and the value must be the name of the Azure Key Vault secret created in the previous step.
 For example, service named `test_service` would be configured like this:
@@ -35,6 +35,24 @@ For example, service named `test_service` would be configured like this:
     "TEST_SERVICE" = "microservicekey-test-service"
     ...
   }
+```
+
+#### <a name="generating-secret"></a>Generating the microservice secret
+
+Here's a sample Java snippet to generate a microservice secret:
+
+```
+byte[] bytes = new byte[10];
+SecureRandom.getInstanceStrong().nextBytes(bytes);
+String secret = new Base32().encodeAsString(bytes);
+```
+
+Sample Python code to generate that secret:
+
+```
+import os
+import base64
+base64.b32encode(os.urandom(10))
 ```
 
 ### Running

--- a/README.md
+++ b/README.md
@@ -18,11 +18,24 @@ $ ./gradlew build
 ```
 
 ### Configuration
-Services to authenticate are retrieved from environment variables in the following format:
+
+In order to setup Service Auth Provider to work with a client service, you need to do the following:
+
+* In the Azure Key Vault named `s2s-{environment}` add the service's secret used for generating OTPs (one-time passwords).
+This has to be done in each environment the service is going to be deployed to. Service Auth Provider will use that secret
+for validating OTPs. It has to be a BASE32-encoded sequence of ten random bytes (16 characters after encoding). By convention,
+the Azure Key Vault secret's name should follow this format: `microservicekey-{service-name}`.
+* Add the client service to `local.microservice_key_names` map in [main.tf](infrastructure/main.tf). The key has to be
+the service name (as in HTTP requests) and the value must be the name of the Azure Key Vault secret created in the previous step.
+For example, service named `test_service` would be configured like this:
+
 ```
-MICROSERVICEKEYS_{service}={secret}
+  microservice_key_names = {
+    ...
+    "TEST_SERVICE" = "microservicekey-test-service"
+    ...
+  }
 ```
-where `{service}` is the name of the service and `{secret}` is a base32 encoded secret used for generating and validating OTP.
 
 ### Running
 To run the app execute:

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -194,47 +194,13 @@ locals {
   microservice_secret_names = "${values(local.microservice_key_names)}"
 
   microservice_key_settings = "${zipmap(
-                                    formatlist("MICROSERVICEKEY_%s", keys(local.microservice_key_names)),
+                                    formatlist("MICROSERVICEKEYS_%s", keys(local.microservice_key_names)),
                                     data.azurerm_key_vault_secret.microservice_keys.*.value
                                 )}"
 
   core_app_settings = {
     JWT_KEY                                     = "${data.vault_generic_secret.jwtKey.data["value"]}"
     TESTING_SUPPORT_ENABLED                     = "${var.testing_support}"
-
-    MICROSERVICEKEYS_CCD_ADMIN                  = "${data.vault_generic_secret.ccdAdmin.data["value"]}"
-    MICROSERVICEKEYS_CCD_DATA                   = "${data.vault_generic_secret.ccdData.data["value"]}"
-    MICROSERVICEKEYS_CCD_DEFINITION             = "${data.vault_generic_secret.ccdDefinition.data["value"]}"
-    MICROSERVICEKEYS_CCD_GW                     = "${data.vault_generic_secret.ccdGw.data["value"]}"
-    MICROSERVICEKEYS_CMC                        = "${data.vault_generic_secret.cmc.data["value"]}"
-    MICROSERVICEKEYS_CMC_LEGAL_FRONTEND         = "${data.vault_generic_secret.cmcLegalFrontend.data["value"]}"
-    MICROSERVICEKEYS_DIVORCE                    = "${data.vault_generic_secret.divorce.data["value"]}"
-    MICROSERVICEKEYS_DIVORCE_CCD_SUBMISSION     = "${data.vault_generic_secret.divorceCcdSubmission.data["value"]}"
-    MICROSERVICEKEYS_DIVORCE_FRONTEND           = "${data.vault_generic_secret.divorceFrontend.data["value"]}"
-    MICROSERVICEKEYS_DIVORCE_CCD_VALIDATION     = "${data.vault_generic_secret.divorceCcdValidation.data["value"]}"
-    MICROSERVICEKEYS_DIVORCE_DOCUMENT_UPLOAD    = "${data.vault_generic_secret.divorceDocumentUpload.data["value"]}"
-    MICROSERVICEKEYS_DIVORCE_DOCUMENT_GENERATOR = "${data.vault_generic_secret.divorceDocumentGenerator.data["value"]}"
-    MICROSERVICEKEYS_DRAFT_STORE_TESTS          = "${data.vault_generic_secret.draftStoreTests.data["value"]}"
-    MICROSERVICEKEYS_JOBSCHEDULER               = "${data.vault_generic_secret.jobscheduler.data["value"]}"
-    MICROSERVICEKEYS_SSCS                       = "${data.vault_generic_secret.sscs.data["value"]}"
-    MICROSERVICEKEYS_SSCS_TRIBUNALS_CASE        = "${data.vault_generic_secret.sscsTribunalsCase.data["value"]}"
-    MICROSERVICEKEYS_PROBATE_FRONTEND           = "${data.vault_generic_secret.probateFrontend.data["value"]}"
-    MICROSERVICEKEYS_PROBATE_BACKEND            = "${data.vault_generic_secret.probateBackend.data["value"]}"
-    MICROSERVICEKEYS_SEND_LETTER_CONSUMER       = "${data.vault_generic_secret.sendLetterConsumer.data["value"]}"
-    MICROSERVICEKEYS_SEND_LETTER_TESTS          = "${data.vault_generic_secret.sendLetterTests.data["value"]}"
-    MICROSERVICEKEYS_REFERENCE                  = "${data.vault_generic_secret.reference.data["value"]}"
-    MICROSERVICEKEYS_EM_GW                      = "${data.vault_generic_secret.emGw.data["value"]}"
-    MICROSERVICEKEYS_CMC_CLAIM_STORE            = "${data.vault_generic_secret.cmcClaimStore.data["value"]}"
-    MICROSERVICEKEYS_CCD_PS                     = "${data.vault_generic_secret.ccdPs.data["value"]}"
-    MICROSERVICEKEYS_FINREM                     = "${data.vault_generic_secret.finRem.data["value"]}"
-    MICROSERVICEKEYS_FINREM_DRAFT_STORE         = "${data.vault_generic_secret.finRemDraftStore.data["value"]}"
-    MICROSERVICEKEYS_JUI_WEBAPP                 = "${data.vault_generic_secret.juiWebapp.data["value"]}"
-    MICROSERVICEKEYS_PUI_WEBAPP                 = "${data.vault_generic_secret.puiWebapp.data["value"]}"
-    MICROSERVICEKEYS_COH_COR                    = "${data.vault_generic_secret.cohcor.data["value"]}"
-    MICROSERVICEKEYS_BULK_SCAN_PROCESSOR        = "${data.vault_generic_secret.bulkScanProcessor.data["value"]}"
-    MICROSERVICEKEYS_BULK_SCAN_PROCESSOR_TESTS  = "${data.vault_generic_secret.bulkScanProcessorTests.data["value"]}"
-    MICROSERVICEKEYS_BULK_SCAN_ORCHESTRATOR     = "${local.microservice_key_settings["MICROSERVICEKEY_BULK_SCAN_ORCHESTRATOR"]}"
-    MICROSERVICEKEYS_BAR_API                    = "${data.vault_generic_secret.barApi.data["value"]}"
   }
 }
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -153,6 +153,11 @@ data "azurerm_key_vault_secret" "microservice_keys" {
   count     = "${length(local.microservice_key_names)}"
 }
 
+data "azurerm_key_vault_secret" "jwt_key" {
+  name      = "jwt-key"
+  vault_uri = "${local.vault_uri}"
+}
+
 locals {
   # name of the service -> name of the vault secret holding the key
   microservice_key_names = {
@@ -199,7 +204,7 @@ locals {
                                 )}"
 
   core_app_settings = {
-    JWT_KEY                                     = "${data.vault_generic_secret.jwtKey.data["value"]}"
+    JWT_KEY                                     = "${data.azurerm_key_vault_secret.jwt_key.value}"
     TESTING_SUPPORT_ENABLED                     = "${var.testing_support}"
   }
 }


### PR DESCRIPTION
Don't merge before Monday, as this change affects all services

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-544

### Change description ###

Make Terraform create application settings based on secrets stored in Azure Vault. Currently it uses secrets from Tactical (Hashicorp) Vault.

Old (hashicorp vault) secrets are still retrieved, but are no longer kept in application settings. They will be removed in a future PR.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
