### PR TITLE
Content negotiation in error handler

### DIFF
--- a/src/main/java/uk/gov/hmcts/auth/provider/service/api/ResponseExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/auth/provider/service/api/ResponseExceptionHandler.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.auth.provider.service.api;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,6 +14,8 @@ import uk.gov.hmcts.auth.provider.service.api.auth.exceptions.UnmappedTokenExcep
 import uk.gov.hmcts.auth.provider.service.api.error.ErrorDto;
 import uk.gov.hmcts.auth.provider.service.api.microservice.UnknownMicroserviceException;
 
+import javax.servlet.http.HttpServletRequest;
+
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.ResponseEntity.status;
 
@@ -19,36 +23,41 @@ import static org.springframework.http.ResponseEntity.status;
 public class ResponseExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(UnknownMicroserviceException.class)
-    protected ResponseEntity<ErrorDto> handleUnknownMicroserviceException() {
-        return unauthorized("Unknown microservice");
+    protected ResponseEntity handleUnknownMicroserviceException(HttpServletRequest req) {
+        return unauthorized("Unknown microservice", req);
     }
 
     @ExceptionHandler(InvalidOneTimePasswordException.class)
-    protected ResponseEntity<ErrorDto> handleInvalidOneTimePasswordException() {
-        return unauthorized("Invalid one-time password");
+    protected ResponseEntity handleInvalidOneTimePasswordException(HttpServletRequest req) {
+        return unauthorized("Invalid one-time password", req);
     }
 
     @ExceptionHandler(TokenSignatureException.class)
-    protected ResponseEntity<ErrorDto> handleTokenSignatureException() {
-        return unauthorized("Invalid token signature");
+    protected ResponseEntity handleTokenSignatureException(HttpServletRequest req) {
+        return unauthorized("Invalid token signature", req);
     }
 
     @ExceptionHandler(TokenExpiredException.class)
-    protected ResponseEntity<ErrorDto> handleTokenExpiredException() {
-        return unauthorized("Token expired");
+    protected ResponseEntity handleTokenExpiredException(HttpServletRequest req) {
+        return unauthorized("Token expired", req);
     }
 
     @ExceptionHandler(UnmappedTokenException.class)
-    protected ResponseEntity<ErrorDto> handleUnmappedTokenException() {
-        return unauthorized("Error verifying token");
+    protected ResponseEntity handleUnmappedTokenException(HttpServletRequest req) {
+        return unauthorized("Error verifying token", req);
     }
 
     @ExceptionHandler(InvalidAuthHeaderException.class)
-    protected ResponseEntity<ErrorDto> handleInvalidAuthHeaderException() {
-        return unauthorized("Invalid authorization header");
+    protected ResponseEntity handleInvalidAuthHeaderException(HttpServletRequest req) {
+        return unauthorized("Invalid authorization header", req);
     }
 
-    private ResponseEntity<ErrorDto> unauthorized(String message) {
-        return status(UNAUTHORIZED).body(new ErrorDto(message));
+    private ResponseEntity unauthorized(String msg, HttpServletRequest req) {
+        if (req.getHeader(HttpHeaders.ACCEPT).equals(MediaType.TEXT_PLAIN_VALUE)) {
+            return status(UNAUTHORIZED).body(msg);
+        } else {
+            // use json by default
+            return status(UNAUTHORIZED).body(new ErrorDto(msg));
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/auth/provider/service/api/componenttests/DetailsComponentTest.java
+++ b/src/test/java/uk/gov/hmcts/auth/provider/service/api/componenttests/DetailsComponentTest.java
@@ -3,13 +3,19 @@ package uk.gov.hmcts.auth.provider.service.api.componenttests;
 import com.google.common.io.BaseEncoding;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.impl.crypto.MacProvider;
-import java.util.Date;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import uk.gov.hmcts.auth.provider.service.api.auth.jwt.JwtHS512Tool;
 import uk.gov.hmcts.auth.provider.service.api.error.ErrorDto;
 
+import java.util.Date;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.IsNot.not;
+import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class DetailsComponentTest extends ComponentTestBase {
 
@@ -62,5 +68,15 @@ public class DetailsComponentTest extends ComponentTestBase {
             .given()
             .when().details("Bearer " + jwt)
             .then().subject(actual -> assertThat(actual).isEqualTo("divorce"));
+    }
+
+    @Test
+    public void should_be_able_to_provide_text_plain_error_if_required_by_the_client() throws Exception {
+        mvc
+            .perform(get("/details")
+                .content("invalid content to trigger error...")
+                .accept(MediaType.TEXT_PLAIN_VALUE)
+            )
+            .andExpect(status().is(not(NOT_ACCEPTABLE.value())));
     }
 }

--- a/src/test/java/uk/gov/hmcts/auth/provider/service/api/componenttests/LeaseComponentTest.java
+++ b/src/test/java/uk/gov/hmcts/auth/provider/service/api/componenttests/LeaseComponentTest.java
@@ -4,10 +4,15 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Value;
-import uk.gov.hmcts.auth.provider.service.api.error.ErrorDto;
+import org.springframework.http.MediaType;
 import uk.gov.hmcts.auth.provider.service.api.auth.totp.TotpAuthenticator;
+import uk.gov.hmcts.auth.provider.service.api.error.ErrorDto;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.core.IsNot.not;
+import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class LeaseComponentTest extends ComponentTestBase {
 
@@ -52,5 +57,15 @@ public class LeaseComponentTest extends ComponentTestBase {
                 Claims claims = Jwts.parser().setSigningKey(jwtKey).parseClaimsJws(token).getBody();
                 assertThat(claims.getSubject()).isEqualTo("divorce");
             });
+    }
+
+    @Test
+    public void should_be_able_to_provide_text_plain_error_if_required_by_the_client() throws Exception {
+        mvc
+            .perform(post("/lease")
+                .content("invalid content to trigger error...")
+                .accept(MediaType.TEXT_PLAIN_VALUE)
+            )
+            .andExpect(status().is(not(NOT_ACCEPTABLE.value())));
     }
 }


### PR DESCRIPTION
Some endpoints return plain text response, while errors are always json objects.
In case client requires `text/plain` (some do: [link](https://github.com/hmcts/service-auth-provider-java-client/blob/master/src/main/java/uk/gov/hmcts/reform/authorisation/ServiceAuthorisationApi.java#L28)) return just the error string.