### PR TITLE
Add S2S key name for cet-frontend

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -52,6 +52,7 @@ locals {
     "EM_ANNOTATION_APP"           = "microservicekey-em-annotation-app"
     "EM_NPA_APP"                  = "microservicekey-em-npa-app"
     "CET"                         = "microservicekey-cet"
+    "CET_FRONTEND"                = "microservicekey-cet-frontend"
     "FPL_CASE_SERVICE"            = "microservicekey-fpl-case-service"
   }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CET-422

### Change description ###
Add S2S key name for cet-frontend
corresponding keys have been added to the various environments as per instructions on the ReadMe file.

#### If you're adding a new secret then do the following ####
Run the script in `./bin/check-all-vaults-for-s2s-secret <new-secret-name>` and paste the output below
This will ensure the secret is in all the vaults it needs to be
```
Max retries exceeded attempting to connect to vault. The vault may not exist or you may need to flush your DNS cache and try again later.
Max retries exceeded attempting to connect to vault. The vault may not exist or you may need to flush your DNS cache and try again later.
Max retries exceeded attempting to connect to vault. The vault may not exist or you may need to flush your DNS cache and try again later.
ERROR: Didn't find secret cet-frontend in environment sandbox
Max retries exceeded attempting to connect to vault. The vault may not exist or you may need to flush your DNS cache and try again later.
ERROR: Didn't find secret cet-frontend in environment saat
INFO: Found secret cet-frontend in environment sprod
INFO: Found secret cet-frontend in environment demo
INFO: Found secret cet-frontend in environment aat
INFO: Found secret cet-frontend in environment prod
```

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

