### PR TITLE
Lock Terraform azurerm provider to 1.19.0

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -1,3 +1,7 @@
+provider "azurerm" {
+  version = "1.19.0"
+}
+
 locals {
   is_preview          = "${var.env == "preview" || var.env == "spreview"}"
 


### PR DESCRIPTION
Hit the azurerm issue trying to deploy this app to saat.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```