### PR TITLE
moving to logging library 4.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,6 @@ def versions = [
   springBoot: plugins.getPlugin('org.springframework.boot').class.package.implementationVersion,
   springfoxSwagger: '2.9.2',
   reformLogging: '4.0.0',
-  logback: '1.2.3'
 ]
 
 dependencies {
@@ -77,8 +76,6 @@ dependencies {
   compile group: 'com.warrenstrange', name: 'googleauth', version: '1.1.2'
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging-appinsights', version: versions.reformLogging
   compile group: 'uk.gov.hmcts.reform', name: 'java-logging', version: versions.reformLogging
-  compile group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback
-  compile group: 'ch.qos.logback', name: 'logback-core', version: versions.logback
 
   compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   compile group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ sonarqube {
 def versions = [
   springBoot: plugins.getPlugin('org.springframework.boot').class.package.implementationVersion,
   springfoxSwagger: '2.9.2',
-  reformLogging: '3.0.1',
+  reformLogging: '4.0.0',
   logback: '1.2.3'
 ]
 
@@ -98,17 +98,18 @@ dependencies {
   }
 }
 
+mainClassName = 'uk.gov.hmcts.auth.provider.service.api.ServiceAuthProviderApplication'
+
 installDist {
   applicationDefaultJvmArgs = ["-Djava.security.egd=file:/dev/./urandom"]
 }
 
 run {
   applicationDefaultJvmArgs = ["-Djava.security.egd=file:/dev/./urandom"]
-  mainClassName = 'uk.gov.hmcts.auth.provider.service.api.ServiceAuthProviderApplication'
 }
 
-jar {
-  archiveName 'service-auth-provider.jar'
+bootJar {
+  archiveName = 'service-auth-provider.jar'
 
   manifest {
     attributes('Implementation-Version': project.version.toString())

--- a/src/main/java/uk/gov/hmcts/auth/provider/service/api/auth/exceptions/InvalidAuthHeaderException.java
+++ b/src/main/java/uk/gov/hmcts/auth/provider/service/api/auth/exceptions/InvalidAuthHeaderException.java
@@ -1,15 +1,4 @@
 package uk.gov.hmcts.auth.provider.service.api.auth.exceptions;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class InvalidAuthHeaderException extends UnknownErrorCodeException {
-
-    public InvalidAuthHeaderException() {
-        super(AlertLevel.P4, (Throwable) null);
-    }
+public class InvalidAuthHeaderException extends RuntimeException {
 }

--- a/src/main/java/uk/gov/hmcts/auth/provider/service/api/auth/exceptions/InvalidOneTimePasswordException.java
+++ b/src/main/java/uk/gov/hmcts/auth/provider/service/api/auth/exceptions/InvalidOneTimePasswordException.java
@@ -1,15 +1,4 @@
 package uk.gov.hmcts.auth.provider.service.api.auth.exceptions;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class InvalidOneTimePasswordException extends UnknownErrorCodeException {
-
-    public InvalidOneTimePasswordException() {
-        super(AlertLevel.P4, (Throwable) null);
-    }
+public class InvalidOneTimePasswordException extends RuntimeException {
 }

--- a/src/main/java/uk/gov/hmcts/auth/provider/service/api/auth/exceptions/TokenExpiredException.java
+++ b/src/main/java/uk/gov/hmcts/auth/provider/service/api/auth/exceptions/TokenExpiredException.java
@@ -1,15 +1,7 @@
 package uk.gov.hmcts.auth.provider.service.api.auth.exceptions;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class TokenExpiredException extends UnknownErrorCodeException {
-
-    public TokenExpiredException(Throwable cause) {
-        super(AlertLevel.P4, cause);
+public class TokenExpiredException extends RuntimeException {
+    public TokenExpiredException( Throwable e ){
+        super(e);
     }
 }

--- a/src/main/java/uk/gov/hmcts/auth/provider/service/api/auth/exceptions/TokenSignatureException.java
+++ b/src/main/java/uk/gov/hmcts/auth/provider/service/api/auth/exceptions/TokenSignatureException.java
@@ -1,15 +1,7 @@
 package uk.gov.hmcts.auth.provider.service.api.auth.exceptions;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class TokenSignatureException extends UnknownErrorCodeException {
-
-    public TokenSignatureException(Throwable cause) {
-        super(AlertLevel.P4, cause);
+public class TokenSignatureException extends RuntimeException {
+    public TokenSignatureException( Throwable e ){
+        super(e);
     }
 }

--- a/src/main/java/uk/gov/hmcts/auth/provider/service/api/auth/exceptions/UnmappedTokenException.java
+++ b/src/main/java/uk/gov/hmcts/auth/provider/service/api/auth/exceptions/UnmappedTokenException.java
@@ -1,15 +1,7 @@
 package uk.gov.hmcts.auth.provider.service.api.auth.exceptions;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class UnmappedTokenException extends UnknownErrorCodeException {
-
-    public UnmappedTokenException(Throwable cause) {
-        super(AlertLevel.P4, cause);
+public class UnmappedTokenException extends RuntimeException {
+    public UnmappedTokenException( Throwable e ){
+        super(e);
     }
 }

--- a/src/main/java/uk/gov/hmcts/auth/provider/service/api/microservice/UnknownMicroserviceException.java
+++ b/src/main/java/uk/gov/hmcts/auth/provider/service/api/microservice/UnknownMicroserviceException.java
@@ -1,15 +1,4 @@
 package uk.gov.hmcts.auth.provider.service.api.microservice;
 
-import uk.gov.hmcts.reform.logging.exception.AlertLevel;
-import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
-
-/**
- * SonarQube reports as error. Max allowed - 5 parents
- */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
-public class UnknownMicroserviceException extends UnknownErrorCodeException {
-
-    UnknownMicroserviceException() {
-        super(AlertLevel.P4, (Throwable) null);
-    }
+public class UnknownMicroserviceException extends RuntimeException {
 }


### PR DESCRIPTION
### Change description ###
The new logging has deprecated the exceptions that were used for alerting which are now not used.

