### PR TITLE
add doc assembly api and template management api keys

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -64,6 +64,8 @@ locals {
     "EM_STITCHING_API"            = "microservicekey-em-stitching-api"
     "EM_CCD_ORCHESTRATOR"         = "microservicekey-em-ccd-orchestrator"
     "CCPAY_BUBBLE"                = "microservicekey-ccpay-bubble"
+    "DG_TEMPLATE_MANAGEMENT_API"  = "microservicekey-dg-template-management-api"
+    "DG_DOCASSEMBLY_API"          = "microservicekey-dg-docassembly-api"
   }
 
   microservice_secret_names = "${values(local.microservice_key_names)}"


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A

### Change description ###
Added document assembly and template management API microservice keys

#### If you're adding a new secret then do the following ####

Template Management API:
INFO: Found secret dg-template-management-api in environment sandbox
INFO: Found secret dg-template-management-api in environment saat
INFO: Found secret dg-template-management-api in environment sprod
INFO: Found secret dg-template-management-api in environment demo
INFO: Found secret dg-template-management-api in environment hmctsdemo
INFO: Found secret dg-template-management-api in environment aat
INFO: Found secret dg-template-management-api in environment prod

Document Assembly API
INFO: Found secret dg-docassembly-api in environment sandbox
INFO: Found secret dg-docassembly-api in environment saat
INFO: Found secret dg-docassembly-api in environment sprod
INFO: Found secret dg-docassembly-api in environment demo
INFO: Found secret dg-docassembly-api in environment hmctsdemo
INFO: Found secret dg-docassembly-api in environment aat
INFO: Found secret dg-docassembly-api in environment prod

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
