### PR TITLE
Add reference data api services

### DIFF
--- a/charts/rpe-service-auth-provider/values.yaml
+++ b/charts/rpe-service-auth-provider/values.yaml
@@ -54,4 +54,6 @@ java:
         - microservicekey-ccpay-bubble
         - microservicekey-dg-template-management
         - microservicekey-dg-docassembly-api
+        - microservicekey-rd-professional-api
+        - microservicekey-rd-user-profile-api
   image: 'https://hmcts.azurecr.io/hmcts/service-auth-provider-app:latest'

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -66,6 +66,8 @@ locals {
     "CCPAY_BUBBLE"                = "microservicekey-ccpay-bubble"
     "DG_TEMPLATE_MANAGEMENT_API"  = "microservicekey-dg-template-management"
     "DG_DOCASSEMBLY_API"          = "microservicekey-dg-docassembly-api"
+    "RD_PROFESSIONAL_API"         = "microservicekey-rd-professional-api"
+    "RD_USER_PROFILE_API"         = "microservicekey-rd-user-profile-api"
   }
 
   microservice_secret_names = "${values(local.microservice_key_names)}"

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -53,3 +53,5 @@ spring:
         s2s.microservicekey-ccpay-bubble: microserviceKeys.ccpay_bubble
         s2s.microservicekey-dg-template-management: microserviceKeys.dg_template_management_api
         s2s.microservicekey-dg-docassembly-api: microserviceKeys.dg_docassembly_api
+        s2s.microservicekey-rd-professional-api: microserviceKeys.rd_professional_api
+        s2s.microservicekey-rd-user-profile-api: microserviceKeys.rd_user_profile_api


### PR DESCRIPTION
Add the following reference data api services:
- rd-professional-api
- rd-user-profile-api

Outputs of bin/check-all-vaults-for-s2s-secret
```
INFO: Found secret rd-professional-api in environment sandbox
INFO: Found secret rd-professional-api in environment saat
INFO: Found secret rd-professional-api in environment sprod
INFO: Found secret rd-professional-api in environment demo
INFO: Found secret rd-professional-api in environment hmctsdemo
INFO: Found secret rd-professional-api in environment aat
INFO: Found secret rd-professional-api in environment prod
```
```
INFO: Found secret rd-user-profile-api in environment sandbox
INFO: Found secret rd-user-profile-api in environment saat
INFO: Found secret rd-user-profile-api in environment sprod
INFO: Found secret rd-user-profile-api in environment demo
INFO: Found secret rd-user-profile-api in environment hmctsdemo
INFO: Found secret rd-user-profile-api in environment aat
INFO: Found secret rd-user-profile-api in environment prod
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
