### PR TITLE
CVE-2020-13943: Bump tomcat to 9.0.39

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,9 +80,9 @@ configurations.all {
         details.useVersion "3.0.2"
         details.because "needed by rest-assured>=4.3"
       }
-      if (details.requested.group in ['org.apache.tomcat.embed']) {	
-        details.useVersion '9.0.37'	
-      }	
+      if (details.requested.group in ['org.apache.tomcat.embed']) {
+        details.useVersion '9.0.39'
+      }
     }
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

N/A

### Change description ###

Bumps tomcat to use 9.039

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
