### PR TITLE
Fix alias for et keys

### DIFF
--- a/charts/rpe-service-auth-provider/Chart.yaml
+++ b/charts/rpe-service-auth-provider/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Service Auth Provider App
 name: rpe-service-auth-provider
 home: https://github.com/hmcts/service-auth-provider-app
-version: 0.3.58
+version: 0.3.59
 maintainers:
   - name: HMCTS Platform engineering team
 dependencies:

--- a/charts/rpe-service-auth-provider/values.yaml
+++ b/charts/rpe-service-auth-provider/values.yaml
@@ -219,9 +219,9 @@ java:
       - name: microservicekey-da-cos-api
         alias: microservicekey.da_cos_api
       - name: microservicekey-et-cos
-        alias: microservicekey.et_cos
+        alias: microserviceKeys.et_cos
       - name: microservicekey-et-msg-handler
-        alias: microservicekey.et_msg_handler
+        alias: microserviceKeys.et_msg_handler
       - name: microservicekey-notifications-service
         alias: microserviceKeys.notifications_service
 


### PR DESCRIPTION
### Change description ###
Fix error in microservice key alias for ET

#### If you're adding a new secret then do the following ####
Run the script in `./bin/set-secret-in-all-vaults <microservice-name>` and paste the output below
This will ensure the secret is in all the vaults it needs to be

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
