### PR TITLE
LAU-172: Adding IdAM-API key.

### DIFF
--- a/charts/rpe-service-auth-provider/Chart.yaml
+++ b/charts/rpe-service-auth-provider/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Service Auth Provider App
 name: rpe-service-auth-provider
 home: https://github.com/hmcts/service-auth-provider-app
-version: 0.3.59
+version: 0.3.60
 maintainers:
   - name: HMCTS Platform engineering team
 dependencies:

--- a/charts/rpe-service-auth-provider/values.yaml
+++ b/charts/rpe-service-auth-provider/values.yaml
@@ -122,6 +122,8 @@ java:
         alias: microserviceKeys.prl_dgs_api
       - name: microservicekey-iac
         alias: microserviceKeys.iac
+      - name: microservicekey-idam-api
+        alias: microserviceKeys.idam_api
       - name: microservicekey-em-stitching-api
         alias: microserviceKeys.em_stitching_api
       - name: microservicekey-em-ccd-orchestrator


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/LAU-172


### Change description ###
Updating the service-auth-provider to support s2s idam-api key.

#### If you're adding a new secret then do the following ####
Run the script in `./bin/set-secret-in-all-vaults <microservice-name>` and paste the output below
This will ensure the secret is in all the vaults it needs to be

service-auth-provider-app davejones$ ./bin/set-secret-in-all-vaults idam-api
INFO: Found secret idam-api in environment demo
INFO: Found secret idam-api in environment aat
INFO: Found secret idam-api in environment prod
INFO: Found secret idam-api in environment perftest
INFO: Found secret idam-api in environment ithc


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
