### PR TITLE
Fix jackson databind

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ dependencies {
   implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
   implementation group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'
-  implementation 'com.fasterxml.jackson.core:jackson-databind' version: '2.13.4.2'
+  implementation group 'com.fasterxml.jackson.core:jackson-databind' version: '2.13.4.2'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.0.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ dependencies {
 
   implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.11'
 
-  implementation 'com.fasterxml.jackson.core.jackson-databind:2.13.4.2'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.4.2'
   implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.3'
 
   compileOnly group: 'net.sourceforge.findbugs', name: 'annotations', version: '1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,7 @@ dependencies {
   implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
   implementation group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'
+  implementation 'com.fasterxml.jackson.core:jackson-databind' version: '2.13.4.2'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.0.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ dependencies {
   implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
   implementation group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'
-  implementation group 'com.fasterxml.jackson.core:jackson-databind' version: '2.13.4.2'
+  implementation group 'com.fasterxml.jackson.core', name: 'jackson-databind' version: '2.13.4.2'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.0.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,7 @@ dependencies {
   implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
   implementation group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'
-  implementation group 'com.fasterxml.jackson.core', name: 'jackson-databind' version: '2.13.4.2'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind' version: '2.13.4.2'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.0.1'
 

--- a/build.gradle
+++ b/build.gradle
@@ -147,7 +147,6 @@ dependencies {
   implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
   implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
   implementation group: 'com.warrenstrange', name: 'googleauth', version: '1.5.0'
-  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind' version: '2.13.4.2'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.0.1'
 
@@ -156,6 +155,7 @@ dependencies {
 
   implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.11'
 
+  implementation 'com.fasterxml.jackson.core.jackson-databind:2.13.4.2'
   implementation 'jakarta.xml.bind:jakarta.xml.bind-api:2.3.3'
 
   compileOnly group: 'net.sourceforge.findbugs', name: 'annotations', version: '1.3.2'


### PR DESCRIPTION
Add jackson databind 2.13.4.2 to avoid CVE warnings about [CVE-2022-42003](https://www.cvedetails.com/cve/CVE-2022-42003/)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
