### PR TITLE
Pact plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'org.sonarqube' version '4.0.0.2929'
   id 'io.spring.dependency-management' version '1.1.0'
   id 'org.springframework.boot' version '2.7.5'
-  id 'au.com.dius.pact' version '4.4.6'
+  id 'au.com.dius.pact' version '4.5.4'
 }
 
 group = 'uk.gov.hmcts.auth.provider.service'


### PR DESCRIPTION
pact_version being updated in earlier PR has broken the pipeline: pact_version: '4.5.4' (https://github.com/hmcts/service-auth-provider-app/pull/673)
https://build.platform.hmcts.net/blue/organizations/jenkins/HMCTS_j_to_z%2Fservice-auth-provider-app/detail/master/77/pipeline/

From this, it looks like au.com.dius.pact should also have been upgraded with it
  contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5', version: versions.pact_version
  contractTestImplementation group: 'au.com.dius.pact.provider', name: 'spring', version: versions.pact_version
  contractTestImplementation group: 'au.com.dius.pact.provider', name: 'junit5spring', version: versions.pact_version

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
