### PR TITLE
revert - pipeline broken since PR 673, pact upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'org.sonarqube' version '4.0.0.2929'
   id 'io.spring.dependency-management' version '1.1.0'
   id 'org.springframework.boot' version '2.7.11'
-  id 'au.com.dius.pact' version '4.5.6'
+  id 'au.com.dius.pact' version '4.4.6'
 }
 
 group = 'uk.gov.hmcts.auth.provider.service'
@@ -105,7 +105,7 @@ sonarqube {
 
 def versions = [
   springBoot: plugins.getPlugin('org.springframework.boot').class.package.implementationVersion,
-  pact_version: '4.5.6',
+  pact_version: '4.1.7',
   junit_jupiter: '5.9.3'
 ]
 


### PR DESCRIPTION
Pipeline broken since https://github.com/hmcts/service-auth-provider-app/pull/673 for Pact

Reverting to make sure that was the issue and then can find the fix

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
