### PR TITLE
Sample health requests aggressively

### DIFF
--- a/lib/applicationinsights.json
+++ b/lib/applicationinsights.json
@@ -2,5 +2,22 @@
   "connectionString": "${file:/mnt/secrets/s2s/app-insights-connection-string}",
   "role": {
     "name": "Service Auth Provider"
+  },
+  "preview": {
+    "sampling": {
+      "overrides": [
+        {
+          "telemetryType": "request",
+          "attributes": [
+            {
+              "key": "http.url",
+              "value": "https?://[^/]+/health.*",
+              "matchType": "regexp"
+            }
+          ],
+          "percentage": 1
+        }
+      ]
+    }
   }
 }


### PR DESCRIPTION
Mirror of https://github.com/hmcts/spring-boot-template/pull/504

There's no need to ingest all health requests we get millions of them in our telemetry, even 1% should be enough to see issues

I've tested this locally in the spring boot template

It's based on the docs at:
https://learn.microsoft.com/en-us/azure/azure-monitor/app/java-standalone-sampling-overrides#example-suppress-collecting-telemetry-for-health-checks

![image](https://github.com/hmcts/spring-boot-template/assets/21194782/902943ca-198d-4115-8ce1-979554223f55)
