### PR TITLE
Rever JUNIT upgrade to test build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,7 +106,7 @@ sonarqube {
 def versions = [
   springBoot: plugins.getPlugin('org.springframework.boot').class.package.implementationVersion,
   pact_version: '4.6.3',
-  junit_jupiter: '5.10.1'
+  junit_jupiter: '5.9.3'
 ]
 
 ext["rest-assured.version"] = '4.5.1'


### PR DESCRIPTION
Seeing if this caused pact provider verification to fail somehow

#### If you're adding a new secret then do the following ####
Run the script in `./bin/set-secret-in-all-vaults <microservice-name>` and paste the output below
This will ensure the secret is in all the vaults it needs to be

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
