### PR TITLE
Update jenkinsfile to run pact verification on PR as well

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -41,9 +41,13 @@ withPipeline(type, product, component) {
     disableLegacyDeployment()
     syncBranchesWithMaster(branchesToSync)
     expires(expiresAfter)
+    
+    onPR() {
+      enablePactAs([AppPipelineDsl.PactRoles.PROVIDER])
+    }
 
     onMaster() {
-        env.PACT_BRANCH_NAME = "master"
-        enablePactAs([AppPipelineDsl.PactRoles.PROVIDER])
+      env.PACT_BRANCH_NAME = "master"
+      enablePactAs([AppPipelineDsl.PactRoles.PROVIDER])
     }
 }


### PR DESCRIPTION
This is making it hard to test/diagnose what is currently causing pact-verification failures as it only runs on master branch


#### If you're adding a new secret then do the following ####
Run the script in `./bin/set-secret-in-all-vaults <microservice-name>` and paste the output below
This will ensure the secret is in all the vaults it needs to be

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
