### PR TITLE
Fix pact tests

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -26,11 +26,6 @@ def component = "service-auth-provider"
 def expiresAfter = "3000-01-01"
 
 // Vars for Kubernetes
-env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
-env.PACT_BROKER_URL = "pact-broker.platform.hmcts.net"
-env.PACT_BROKER_PORT = "443"
-env.PACT_BROKER_SCHEME = "https"
-
 def branchesToSync = ['demo', 'perftest', 'ithc']
 
 withPipeline(type, product, component) {

--- a/src/contractTest/java/uk/gov/hmcts/auth/provider/service/api/auth/AuthControllerProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/auth/provider/service/api/auth/AuthControllerProviderTest.java
@@ -23,8 +23,14 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @Provider("s2s_auth")
-@PactBroker(scheme = "${PACT_BROKER_SCHEME:http}", host = "${PACT_BROKER_URL:localhost}", port = "${PACT_BROKER_PORT:80}", consumerVersionSelectors = {
-    @VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")})
+@PactBroker(
+    url = "${PACT_BROKER_URL:https://pact-broker.platform.hmcts.net}",
+    consumerVersionSelectors = {
+        @VersionSelector(tag = "${PACT_BRANCH_NAME:Dev}")
+    },
+    providerTags = "${pactbroker.providerTags:master}",
+    enablePendingPacts = "${pactbroker.enablePending:true}"
+)
 @ContextConfiguration(classes = AuthControllerProviderContext.class)
 public class AuthControllerProviderTest {
 


### PR DESCRIPTION
XUI broke the pact tests in https://github.com/hmcts/rpx-xui-approve-org/pull/798 and https://github.com/hmcts/rpx-xui-webapp/pull/3362

They specified the wrong content type response and changed the state name from a valid one to one that didn't exist.

Failures:
* `Pact between xui_approveorg (b202ce9) and s2s_auth - The url, the password and microservice`
* `Pact between xui_webApp (e5f42ea) and s2s_auth - The url, the password and microservice`

Also a PRL one was failing:
* `Pact between prl_cos_api (6127edc6b) and s2s_auth - a request for a token`

not looked at the prl one.