### PR TITLE
DTSPO-15909 - updating app insights to module

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -14,22 +14,23 @@ resource "azurerm_resource_group" "rg" {
   tags = var.common_tags
 }
 
-resource "azurerm_application_insights" "appinsights" {
-  name                = "${var.product}-${var.component}-appinsights-${var.env}"
-  location            = var.appinsights_location
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env     = var.env
+  product = var.product
+  name    = "${var.product}-${var.component}-appinsights"
+
   resource_group_name = azurerm_resource_group.rg.name
-  application_type    = "web"
 
-  tags = var.common_tags
-
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance
-      application_type,
-    ]
-  }
+  common_tags = var.common_tags
 }
+
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
+}
+
 
 data "azurerm_user_assigned_identity" "rpe-shared-identity" {
   name                = "rpe-shared-${var.env}-mi"
@@ -53,6 +54,6 @@ module "key-vault" {
 
 resource "azurerm_key_vault_secret" "connection-string" {
   name         = "app-insights-connection-string"
-  value        = azurerm_application_insights.appinsights.connection_string
+  value        = module.application_insights.appinsights.connection_string
   key_vault_id = module.key-vault.key_vault_id
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -54,6 +54,6 @@ module "key-vault" {
 
 resource "azurerm_key_vault_secret" "connection-string" {
   name         = "app-insights-connection-string"
-  value        = module.application_insights.appinsights.connection_string
+  value        = module.application_insights.connection_string
   key_vault_id = module.key-vault.key_vault_id
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -17,9 +17,10 @@ resource "azurerm_resource_group" "rg" {
 module "application_insights" {
   source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
 
-  env     = var.env
-  product = var.product
-  name    = "${var.product}-${var.component}-appinsights"
+  env      = var.env
+  product  = var.product
+  name     = "${var.product}-${var.component}-appinsights"
+  location = var.appinsights_location
 
   resource_group_name = azurerm_resource_group.rg.name
 


### PR DESCRIPTION
Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

Change description
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.