### PR TITLE
Revert "Remove sandbox from script"

### DIFF
--- a/bin/check-all-vaults-for-s2s-secret
+++ b/bin/check-all-vaults-for-s2s-secret
@@ -26,6 +26,7 @@ function check_for_environment() {
 
 }
 
+check_for_environment sandbox
 check_for_environment demo
 check_for_environment aat
 check_for_environment prod

--- a/bin/set-secret-in-all-vaults
+++ b/bin/set-secret-in-all-vaults
@@ -18,6 +18,7 @@ function keyvaultSet() {
   az keyvault secret set --vault-name s2s-${env} --name microservicekey-${name} --value ${secret} > /dev/null
 }
 
+keyvaultSet sandbox ${1}
 keyvaultSet demo ${1}
 keyvaultSet aat ${1}
 keyvaultSet prod ${1}


### PR DESCRIPTION
Reverts hmcts/service-auth-provider-app#252

A new secret was created for [st-cron](https://github.com/hmcts/service-auth-provider-app/pull/950) which is causing sandbox pods to fail because it doesn't exist in the sandbox vault which has been recreated since this original PR was merged