### PR TITLE
Revert "Update junit5 monorepo"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ sonarqube {
 
 def versions = [
   pact_version: '4.6.17',
-  junit_jupiter: '5.12.0'
+  junit_jupiter: '5.11.4'
 ]
 
 configurations.all {
@@ -159,7 +159,7 @@ dependencies {
   contractTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit_jupiter
   contractTestRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit_jupiter
   contractTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit_jupiter
-  contractTestRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.12.0'
+  contractTestRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.11.4'
 
   testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test'){
     exclude(module: 'commons-logging')


### PR DESCRIPTION
Reverts hmcts/service-auth-provider-app#1046

### **Revert JUnit 5.12.0 Upgrade to Fix Test Execution Errors**

**Description** 

- This PR reverts the recent update of `JUnit 5.12.0` and `junit-platform-commons 1.12.0` back to `JUnit 5.11.4` and `junit-platform-commons 1.11.4`. The upgrade caused test discovery failures due to incompatibility between `JUnit 5.12.0` and the JUnit Platform version used.


**Issue**

- The project was updated to `JUnit 5.12.0` but continued using `junit-platform-commons 1.12.0`.
- This mismatch caused a `NoSuchMethodError` during test discovery because `junit-jupiter-engine 5.12.0` expects a `method (getOutputDirectoryProvider())` that does not exist in `junit-platform-commons 1.12.0`.
- As a result, tests failed to execute with errors in `JUnitPlatformTestClassProcessor`.


**Changes Reverted**

- **JUnit Jupiter** downgraded from `5.12.0` → `5.11.4`.
- **JUnit Platform Commons** downgraded from `1.12.0` → `1.11.4`.