### PR TITLE
PAY-7869: Adding new CCPAY API Gateway S2S Secret

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,11 @@
   "extends": [
     "github>hmcts/.github//renovate/automerge-all",
     "local>hmcts/.github:renovate-config"
+  ],
+  "packageRules": [
+    {
+      "groupName": "org.junit.jupiter",
+      "enabled": false
+    }
   ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ sourceSets {
 repositories {
   mavenLocal()
   mavenCentral()
-  maven { url 'https://jitpack.io' }
+  maven { url = 'https://pkgs.dev.azure.com/hmcts/Artifacts/_packaging/hmcts-lib/maven/v1' }
 }
 
 // https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ sonarqube {
 
 def versions = [
   pact_version: '4.6.17',
-  junit_jupiter: '5.13.1'
+  junit_jupiter: '5.11.4'
 ]
 
 configurations.all {
@@ -159,7 +159,7 @@ dependencies {
   contractTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit_jupiter
   contractTestRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit_jupiter
   contractTestImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit_jupiter
-  contractTestRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.13.2'
+  contractTestRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-commons', version: '1.11.4'
 
   testImplementation(group: 'org.springframework.boot', name: 'spring-boot-starter-test'){
     exclude(module: 'commons-logging')

--- a/charts/rpe-service-auth-provider/Chart.yaml
+++ b/charts/rpe-service-auth-provider/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Service Auth Provider App
 name: rpe-service-auth-provider
 home: https://github.com/hmcts/service-auth-provider-app
-version: 0.3.125
+version: 0.3.126
 maintainers:
   - name: HMCTS Platform engineering team
 dependencies:

--- a/charts/rpe-service-auth-provider/values.yaml
+++ b/charts/rpe-service-auth-provider/values.yaml
@@ -32,6 +32,8 @@ java:
         alias: microserviceKeys.ccd_gw
       - name: microservicekey-ccd-ps
         alias: microserviceKeys.ccd_ps
+      - name: microservicekey-ccpay-gw
+        alias: microserviceKeys.ccpay_gw
       - name: microservicekey-cmc
         alias: microserviceKeys.cmc
       - name: microservicekey-cmcLegalFrontend


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PAY-7869


### Change description ###
I've put a block on renovate updating the jupiter libraries for now as this is breaking the pact testing.
The change is to support Fee and Payments components using it's own s2s secret for the API Gateway instead of the shared secret 'api-gw'.

#### If you're adding a new secret then do the following ####
Run the script in `./bin/set-secret-in-all-vaults <microservice-name>` and paste the output below
This will ensure the secret is in all the vaults it needs to be

Only relevant s2s environments being shown.

./check-all-vaults-for-s2s-secret ccpay-gw
INFO: Found secret ccpay-gw in environment sandbox
INFO: Found secret ccpay-gw in environment prod
INFO: Found secret ccpay-gw in environment demo
INFO: Found secret ccpay-gw in environment aat
INFO: Found secret ccpay-gw in environment perftest
INFO: Found secret ccpay-gw in environment ithc

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
