### PR TITLE
Grant new jenkins MIs access to KVs

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -45,6 +45,7 @@ module "key-vault" {
   env                 = var.env
   tenant_id           = var.tenant_id
   object_id           = var.jenkins_AAD_objectId
+  jenkins_object_id   = data.azurerm_user_assigned_identity.jenkins.principal_id
   resource_group_name = azurerm_resource_group.rg.name
 
   # dcd_reform_dev_logs group object ID
@@ -52,6 +53,11 @@ module "key-vault" {
   common_tags             = var.common_tags
 
   managed_identity_object_ids = [data.azurerm_user_assigned_identity.rpe-shared-identity.principal_id]
+}
+
+data "azurerm_user_assigned_identity" "jenkins" {
+  name                = "jenkins-${var.env}-mi"
+  resource_group_name = "managed-identities-${var.env}-rg"
 }
 
 resource "azurerm_key_vault_secret" "connection-string" {


### PR DESCRIPTION
### JIRA link (if applicable) ###
[DTSPO-30512](https://tools.hmcts.net/jira/browse/DTSPO-30512)


### Change description ###
- Granting new Jenkins managed identities access to s2s key vaults


#### If you're adding a new secret then do the following ####
Run the script in `./bin/set-secret-in-all-vaults <microservice-name>` and paste the output below
This will ensure the secret is in all the vaults it needs to be

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
