### PR TITLE
DTSPO-30107: grant preview Jenkins MI s2s vault access

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -2,6 +2,12 @@ provider "azurerm" {
   features {}
 }
 
+provider "azurerm" {
+  alias           = "cnp_dev"
+  subscription_id = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+  features {}
+}
+
 locals {
   vault_uri  = module.key-vault.key_vault_uri
   vault_name = module.key-vault.key_vault_name
@@ -39,6 +45,16 @@ data "azurerm_user_assigned_identity" "rpe-shared-identity" {
   resource_group_name = "managed-identities-${var.env}-rg"
 }
 
+data "azurerm_user_assigned_identity" "jenkins-preview" {
+  provider = azurerm.cnp_dev
+
+  # Temporary exception for DTSPO-30107: Civil preview deploys currently read
+  # AAT team secrets because the Jenkins library maps preview vaults to AAT.
+  # Remove once preview secret loading no longer requires AAT vault access.
+  name                = "jenkins-preview-mi"
+  resource_group_name = "managed-identities-preview-rg"
+}
+
 module "key-vault" {
   source              = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
   product             = "s2s"
@@ -52,7 +68,14 @@ module "key-vault" {
   product_group_object_id = "70de400b-4f47-4f25-a4f0-45e1ee4e4ae3"
   common_tags             = var.common_tags
 
-  managed_identity_object_ids = [data.azurerm_user_assigned_identity.rpe-shared-identity.principal_id]
+  managed_identity_object_ids = concat(
+    [
+      data.azurerm_user_assigned_identity.rpe-shared-identity.principal_id,
+    ],
+    var.env == "aat" ? [
+      data.azurerm_user_assigned_identity.jenkins-preview.principal_id,
+    ] : []
+  )
 }
 
 data "azurerm_user_assigned_identity" "jenkins" {


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

See [DTSPO-30108](https://tools.hmcts.net/jira/browse/DTSPO-30108)

### Change description ###
Jenkins preview deploys currently load AAT team secrets because Jenkins maps preview -> aat; this grants jenkins-preview-mi read-only access until preview secret loading is redesigned.

#### If you're adding a new secret then do the following ####
Run the script in `./bin/set-secret-in-all-vaults <microservice-name>` and paste the output below
This will ensure the secret is in all the vaults it needs to be

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
