### PR TITLE
DTSPO-30107: grant preview Jenkins MI s2s vault access

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -3,8 +3,9 @@ provider "azurerm" {
 }
 
 provider "azurerm" {
-  alias           = "cnp_dev"
-  subscription_id = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+  alias                           = "cnp_dev"
+  subscription_id                 = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+  resource_provider_registrations = "none"
   features {}
 }
 
@@ -47,6 +48,7 @@ data "azurerm_user_assigned_identity" "rpe-shared-identity" {
 
 data "azurerm_user_assigned_identity" "jenkins-preview" {
   provider = azurerm.cnp_dev
+  count    = var.env == "aat" ? 1 : 0
 
   # Temporary exception for DTSPO-30107: Civil preview deploys currently read
   # AAT team secrets because the Jenkins library maps preview vaults to AAT.
@@ -73,7 +75,7 @@ module "key-vault" {
       data.azurerm_user_assigned_identity.rpe-shared-identity.principal_id,
     ],
     var.env == "aat" ? [
-      data.azurerm_user_assigned_identity.jenkins-preview.principal_id,
+      data.azurerm_user_assigned_identity.jenkins-preview[0].principal_id,
     ] : []
   )
 }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:
Temporary DTSPO-30107 exception to allow Jenkins preview agents to read AAT Key Vault secrets during preview deploys.

### JIRA link (if applicable) ###

See [DTSPO-30108](https://tools.hmcts.net/jira/browse/DTSPO-30108)

### Change description ###
Jenkins preview deploys currently load AAT team secrets because Jenkins maps preview -> aat; this grants jenkins-preview-mi read-only access until preview secret loading is redesigned.

#### If you're adding a new secret then do the following ####
Run the script in `./bin/set-secret-in-all-vaults <microservice-name>` and paste the output below
This will ensure the secret is in all the vaults it needs to be

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
