### PR TITLE
Add WA reporting frontend S2S secret

### DIFF
--- a/charts/rpe-service-auth-provider/Chart.yaml
+++ b/charts/rpe-service-auth-provider/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for Service Auth Provider App
 name: rpe-service-auth-provider
 home: https://github.com/hmcts/service-auth-provider-app
-version: 0.3.137
+version: 0.3.138
 maintainers:
   - name: HMCTS Platform engineering team
 dependencies:

--- a/charts/rpe-service-auth-provider/values.yaml
+++ b/charts/rpe-service-auth-provider/values.yaml
@@ -184,6 +184,8 @@ java:
         alias: microserviceKeys.rd_location_ref_data_load
       - name: microservicekey-wa-camunda-pipeline-upload
         alias: microserviceKeys.wa_camunda_pipeline_upload
+      - name: microservicekey-wa-reporting-frontend
+        alias: microserviceKeys.wa_reporting_frontend
       - name: microservicekey-wa-workflow-api
         alias: microserviceKeys.wa_workflow_api
       - name: microservicekey-wa-task-management-api


### PR DESCRIPTION
## Summary
- Add `microservicekey-wa-reporting-frontend` to the S2S chart Key Vault mappings as `microserviceKeys.wa_reporting_frontend`.
- Bump the `rpe-service-auth-provider` chart version from `0.3.137` to `0.3.138`.

## Secret setup
- The `microservicekey-wa-reporting-frontend` secret has been added to the required `s2s-<env>` vaults.

## Related PRs
- WA Reporting frontend: https://github.com/hmcts/wa-reporting-frontend/pull/367
- RAS allow-list: https://github.com/hmcts/am-role-assignment-service/pull/2758

## Verification
- `git diff --check`